### PR TITLE
#18 fix typos in TOPOLOGYHIDE route

### DIFF
--- a/SbcOS/configs/voice/kamailio/kamailio.cfg
+++ b/SbcOS/configs/voice/kamailio/kamailio.cfg
@@ -730,16 +730,27 @@ route[REGISTRAR] {
 }
 
 route[TOPOLOGYHIDE] {
-	if(is_method("INVITE") && !strempty($sel(cfg_get.topology.hostname_hide))) 
-	{
-		$var(from)="sip:"+$fU+"@"+$sel(cfg_get.topology.hostname_hide);
-		else $var(from)="sip:"+$sel(cfg_get.topology.hostname_hide);
-		if(defined $tU && !strempty($tU)) $var(to)="sip:"+$tU+"@"+$sel(cfg_get.topology.hostname_hide);
-		else $var(to)="sip:"+$sel(cfg_get.topology.hostname_hide);
-		uac_replace_from("$var(from)");
-		uac_replace_to("$var(to)");
-	}
+        if(is_method("INVITE") && !strempty($sel(cfg_get.topology.hostname_hide)))
+        {
+
+                if(defined $fU && !strempty($fU)) {
+                        $var(from)="sip:"+$fU+"@"+$sel(cfg_get.topology.hostname_hide);
+                }
+                else {
+                        $var(from)="sip:"+$sel(cfg_get.topology.hostname_hide);
+                }
+
+                if(defined $tU && !strempty($tU)) {
+                        $var(to)="sip:"+$tU+"@"+$sel(cfg_get.topology.hostname_hide);
+                }
+                else {
+                        $var(to)="sip:"+$sel(cfg_get.topology.hostname_hide);
+                }
+                uac_replace_from("$var(from)");
+                uac_replace_to("$var(to)");
+        }
 }
+
 
 
 # Presence server processing


### PR DESCRIPTION
There are no brackets around the if/else in that route - which breaks then kamailios config language.